### PR TITLE
fixed links in docstrings of svm.SVC and svm.SVR

### DIFF
--- a/sklearn/svm/classes.py
+++ b/sklearn/svm/classes.py
@@ -439,7 +439,7 @@ class SVC(BaseSVC):
     The implementation is based on libsvm. The fit time scales at least
     quadratically with the number of samples and may be impractical
     beyond tens of thousands of samples. For large datasets
-    consider using :class:`sklearn.linear_model.LinearSVC` or
+    consider using :class:`sklearn.svm.LinearSVC` or
     :class:`sklearn.linear_model.SGDClassifier` instead, possibly after a
     :class:`sklearn.kernel_approximation.Nystroem` transformer.
 
@@ -863,7 +863,7 @@ class SVR(RegressorMixin, BaseLibSVM):
     The implementation is based on libsvm. The fit time complexity
     is more than quadratic with the number of samples which makes it hard
     to scale to datasets with more than a couple of 10000 samples. For large
-    datasets consider using :class:`sklearn.linear_model.LinearSVR` or
+    datasets consider using :class:`sklearn.svm.LinearSVR` or
     :class:`sklearn.linear_model.SGDRegressor` instead, possibly after a
     :class:`sklearn.kernel_approximation.Nystroem` transformer.
 


### PR DESCRIPTION
This PR fixes a typo in two docstrings. LinearSVR and LinearSVC are not in the linear_model subpackage but in svm (see sklearn/svm/__init__.py), thus the doc generation does not generate hyperlinks.

See missing link in the generated docs here: https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html